### PR TITLE
Make Logger accept only Target instances

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,6 @@
         "yiisoft/yii-web": "^3.0@dev",
         "yiisoft/cache": "^3.0@dev",
         "yiisoft/di": "^3.0@dev",
-        "yiisoft/log-target-syslog": "^3.0@dev",
         "hiqdev/composer-config-plugin": "^1.0@dev"
     },
     "provide": {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -13,7 +13,6 @@ use Psr\Log\LoggerTrait;
 use Psr\Log\LogLevel;
 use yii\base\ErrorHandler;
 use yii\helpers\VarDumper;
-use yii\helpers\Yii;
 
 /**
  * Logger records logged messages in memory and sends them to different targets according to [[targets]].
@@ -76,22 +75,19 @@ class Logger implements LoggerInterface
     public $traceLevel = 0;
 
     /**
-     * @var array|Target[] the log targets. Each array element represents a single [[Target|log target]] instance
-     * or the configuration for creating the log target instance.
+     * @var Target[] the log targets. Each array element represents a single [[Target|log target]] instance
      */
     private $_targets = [];
-    /**
-     * @var bool whether [[targets]] have been initialized, e.g. ensured to be objects.
-     */
-    private $_isTargetsInitialized = false;
-
 
     /**
      * Initializes the logger by registering [[flush()]] as a shutdown function.
+     *
+     * @param Target[] $targets the log targets.
      */
     public function __construct(array $targets = [])
     {
         $this->setTargets($targets);
+
         register_shutdown_function(function () {
             // make regular flush before other shutdown functions, which allows session data collection and so on
             $this->flush();
@@ -106,14 +102,6 @@ class Logger implements LoggerInterface
      */
     public function getTargets(): array
     {
-        if (!$this->_isTargetsInitialized) {
-            foreach ($this->_targets as $name => $target) {
-                if (!$target instanceof Target) {
-                    $this->_targets[$name] = Yii::createObject($target);
-                }
-            }
-            $this->_isTargetsInitialized = true;
-        }
         return $this->_targets;
     }
 
@@ -129,26 +117,22 @@ class Logger implements LoggerInterface
     }
 
     /**
-     * @param array|Target[] $targets the log targets. Each array element represents a single [[Target|log target]] instance
+     * @param Target[] $targets the log targets. Each array element represents a single [[Target|log target]] instance
      * or the configuration for creating the log target instance.
      */
     public function setTargets(array $targets): void
     {
         $this->_targets = $targets;
-        $this->_isTargetsInitialized = false;
     }
 
     /**
      * Adds extra target to [[targets]].
-     * @param Target|array $target the log target instance or its DI compatible configuration.
+     * @param Target $target the log target instance.
      * @param string|null $name array key to be used to store target, if `null` is given target will be append
      * to the end of the array by natural integer key.
      */
-    public function addTarget($target, string $name = null)
+    public function addTarget(Target $target, string $name = null)
     {
-        if (!$target instanceof Target) {
-            $this->_isTargetsInitialized = false;
-        }
         if ($name === null) {
             $this->_targets[] = $target;
         } else {
@@ -300,7 +284,7 @@ class Logger implements LoggerInterface
      */
     public function getElapsedTime(): float
     {
-        return microtime(true) - YII_BEGIN_TIME;
+        return \microtime(true) - YII_BEGIN_TIME;
     }
 
     /**

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -122,6 +122,11 @@ class Logger implements LoggerInterface
      */
     public function setTargets(array $targets): void
     {
+        foreach ($targets as $target) {
+            if (!$target instanceof Target) {
+                throw new InvalidArgumentException('You must provide an instance of \Yii\Log\Target.');
+            }
+        }
         $this->_targets = $targets;
     }
 

--- a/src/LoggerTarget.php
+++ b/src/LoggerTarget.php
@@ -65,7 +65,7 @@ class LoggerTarget extends Target
      * @return LoggerInterface logger instance.
      * @throws InvalidConfigException if logger is not set.
      */
-    public function getLogger()
+    public function getLogger(): LoggerInterface
     {
         if ($this->_logger === null) {
             throw new InvalidConfigException('"' . get_class($this) . '::$logger" must be set to be "' . LoggerInterface::class . '" instance');

--- a/tests/LoggerDispatchingTest.php
+++ b/tests/LoggerDispatchingTest.php
@@ -22,7 +22,6 @@ namespace Yii\Log\Tests {
     use yii\helpers\Yii;
     use yii\exceptions\UserException;
     use Yii\Log\Logger;
-    use Yii\Log\SyslogTarget;
     use yii\tests\TestCase;
 
     /**
@@ -142,20 +141,6 @@ namespace Yii\Log\Tests {
 
             $logger->messages = 'messages';
             $logger->flush(true);
-        }
-
-        /**
-         * @covers \Yii\Log\Logger::__construct()
-         */
-        public function testConstructWithCreateTargetObject()
-        {
-            $logger = new Logger([
-                'syslog' => [
-                    '__class' => SyslogTarget::class,
-                ],
-            ]);
-
-            $this->assertEquals($logger->getTarget('syslog'), Yii::createObject(SyslogTarget::class));
         }
 
         /**

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -160,14 +160,6 @@ class LoggerTest extends TestCase
 
         $this->assertEquals([$target], $logger->getTargets());
         $this->assertSame($target, $logger->getTargets()[0]);
-
-        $logger->setTargets([
-            [
-                '__class' => get_class($target),
-            ],
-        ]);
-        $this->assertNotSame($target, $logger->getTarget(0));
-        $this->assertEquals(get_class($target), get_class($logger->getTarget(0)));
     }
 
     /**


### PR DESCRIPTION
Fixed issue #11 by accepting only `Target` instances for Logger.