### PR TITLE
Mirror Psr\LogLevel constants in Logger

### DIFF
--- a/src/Logger.php
+++ b/src/Logger.php
@@ -29,6 +29,15 @@ class Logger implements LoggerInterface
 {
     use LoggerTrait;
 
+    const EMERGENCY = LogLevel::EMERGENCY;
+    const ALERT     = LogLevel::ALERT;
+    const CRITICAL  = LogLevel::CRITICAL;
+    const ERROR     = LogLevel::ERROR;
+    const WARNING   = LogLevel::WARNING;
+    const NOTICE    = LogLevel::NOTICE;
+    const INFO      = LogLevel::INFO;
+    const DEBUG     = LogLevel::DEBUG;
+
     /**
      * @var array logged messages. This property is managed by [[log()]] and [[flush()]].
      * Each log message is of the following structure:

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -29,14 +29,14 @@ class Logger implements LoggerInterface
 {
     use LoggerTrait;
 
-    const EMERGENCY = LogLevel::EMERGENCY;
-    const ALERT     = LogLevel::ALERT;
-    const CRITICAL  = LogLevel::CRITICAL;
-    const ERROR     = LogLevel::ERROR;
-    const WARNING   = LogLevel::WARNING;
-    const NOTICE    = LogLevel::NOTICE;
-    const INFO      = LogLevel::INFO;
-    const DEBUG     = LogLevel::DEBUG;
+    public const EMERGENCY = LogLevel::EMERGENCY;
+    public const ALERT     = LogLevel::ALERT;
+    public const CRITICAL  = LogLevel::CRITICAL;
+    public const ERROR     = LogLevel::ERROR;
+    public const WARNING   = LogLevel::WARNING;
+    public const NOTICE    = LogLevel::NOTICE;
+    public const INFO      = LogLevel::INFO;
+    public const DEBUG     = LogLevel::DEBUG;
 
     /**
      * @var array logged messages. This property is managed by [[log()]] and [[flush()]].

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -29,14 +29,14 @@ class Logger implements LoggerInterface
 {
     use LoggerTrait;
 
-    public const EMERGENCY = LogLevel::EMERGENCY;
-    public const ALERT     = LogLevel::ALERT;
-    public const CRITICAL  = LogLevel::CRITICAL;
-    public const ERROR     = LogLevel::ERROR;
-    public const WARNING   = LogLevel::WARNING;
-    public const NOTICE    = LogLevel::NOTICE;
-    public const INFO      = LogLevel::INFO;
-    public const DEBUG     = LogLevel::DEBUG;
+    public const EMERGENCY_LEVEL = LogLevel::EMERGENCY;
+    public const ALERT_LEVEL     = LogLevel::ALERT;
+    public const CRITICAL_LEVEL  = LogLevel::CRITICAL;
+    public const ERROR_LEVEL     = LogLevel::ERROR;
+    public const WARNING_LEVEL   = LogLevel::WARNING;
+    public const NOTICE_LEVEL    = LogLevel::NOTICE;
+    public const INFO_LEVEL      = LogLevel::INFO;
+    public const DEBUG_LEVEL     = LogLevel::DEBUG;
 
     /**
      * @var array logged messages. This property is managed by [[log()]] and [[flush()]].

--- a/tests/LoggerDispatchingTest.php
+++ b/tests/LoggerDispatchingTest.php
@@ -21,7 +21,6 @@ namespace Yiisoft\Log {
 
 namespace Yiisoft\Log\Tests {
 
-    use Psr\Log\LogLevel;
     use Yiisoft\Log\Logger;
     use Yiisoft\Log\Target;
     use PHPUnit\Framework\TestCase;
@@ -116,7 +115,7 @@ namespace Yiisoft\Log\Tests {
                     [
                         [[
                             'Unable to send log via ' . get_class($target1) . ': Exception: some error',
-                            LogLevel::WARNING,
+                            Logger::WARNING,
                             'Yiisoft\Log\Logger::dispatch',
                             'time data',
                             [],

--- a/tests/LoggerDispatchingTest.php
+++ b/tests/LoggerDispatchingTest.php
@@ -115,7 +115,7 @@ namespace Yiisoft\Log\Tests {
                     [
                         [[
                             'Unable to send log via ' . get_class($target1) . ': Exception: some error',
-                            Logger::WARNING,
+                            Logger::WARNING_LEVEL,
                             'Yiisoft\Log\Logger::dispatch',
                             'time data',
                             [],

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -7,7 +7,6 @@
 
 namespace Yiisoft\Log\Tests;
 
-use Psr\Log\LogLevel;
 use Yiisoft\Log\Logger;
 use Yiisoft\Log\Target;
 use PHPUnit\Framework\TestCase;
@@ -35,17 +34,17 @@ class LoggerTest extends TestCase
     public function testLog()
     {
         $memory = memory_get_usage();
-        $this->logger->log(LogLevel::INFO, 'test1');
+        $this->logger->log(Logger::INFO, 'test1');
         $this->assertCount(1, $this->logger->messages);
-        $this->assertEquals(LogLevel::INFO, $this->logger->messages[0][0]);
+        $this->assertEquals(Logger::INFO, $this->logger->messages[0][0]);
         $this->assertEquals('test1', $this->logger->messages[0][1]);
         $this->assertEquals('application', $this->logger->messages[0][2]['category']);
         $this->assertEquals([], $this->logger->messages[0][2]['trace']);
         $this->assertGreaterThanOrEqual($memory, $this->logger->messages[0][2]['memory']);
 
-        $this->logger->log(LogLevel::ERROR, 'test2', ['category' => 'category']);
+        $this->logger->log(Logger::ERROR, 'test2', ['category' => 'category']);
         $this->assertCount(2, $this->logger->messages);
-        $this->assertEquals(LogLevel::ERROR, $this->logger->messages[1][0]);
+        $this->assertEquals(Logger::ERROR, $this->logger->messages[1][0]);
         $this->assertEquals('test2', $this->logger->messages[1][1]);
         $this->assertEquals('category', $this->logger->messages[1][2]['category']);
         $this->assertEquals([], $this->logger->messages[1][2]['trace']);
@@ -59,14 +58,14 @@ class LoggerTest extends TestCase
     {
         $memory = memory_get_usage();
         $this->logger->setTraceLevel(3);
-        $this->logger->log(LogLevel::INFO, 'test3');
+        $this->logger->log(Logger::INFO, 'test3');
         $this->assertCount(1, $this->logger->messages);
-        $this->assertEquals(LogLevel::INFO, $this->logger->messages[0][0]);
+        $this->assertEquals(Logger::INFO, $this->logger->messages[0][0]);
         $this->assertEquals('test3', $this->logger->messages[0][1]);
         $this->assertEquals('application', $this->logger->messages[0][2]['category']);
         $this->assertEquals([
             'file' => __FILE__,
-            'line' => 62,
+            'line' => 61,
             'function' => 'log',
             'class' => Logger::class,
             'type' => '->',
@@ -102,7 +101,7 @@ class LoggerTest extends TestCase
             ->getMock();
         $logger->setFlushInterval(1);
         $logger->expects($this->exactly(1))->method('flush');
-        $logger->log(LogLevel::INFO, 'test1');
+        $logger->log(Logger::INFO, 'test1');
     }
 
     /**
@@ -153,13 +152,13 @@ class LoggerTest extends TestCase
      */
     public function testGetLevelName()
     {
-        $this->assertEquals('info', Logger::getLevelName(LogLevel::INFO));
-        $this->assertEquals('error', Logger::getLevelName(LogLevel::ERROR));
-        $this->assertEquals('warning', Logger::getLevelName(LogLevel::WARNING));
-        $this->assertEquals('debug', Logger::getLevelName(LogLevel::DEBUG));
-        $this->assertEquals('emergency', Logger::getLevelName(LogLevel::EMERGENCY));
-        $this->assertEquals('alert', Logger::getLevelName(LogLevel::ALERT));
-        $this->assertEquals('critical', Logger::getLevelName(LogLevel::CRITICAL));
+        $this->assertEquals('info', Logger::getLevelName(Logger::INFO));
+        $this->assertEquals('error', Logger::getLevelName(Logger::ERROR));
+        $this->assertEquals('warning', Logger::getLevelName(Logger::WARNING));
+        $this->assertEquals('debug', Logger::getLevelName(Logger::DEBUG));
+        $this->assertEquals('emergency', Logger::getLevelName(Logger::EMERGENCY));
+        $this->assertEquals('alert', Logger::getLevelName(Logger::ALERT));
+        $this->assertEquals('critical', Logger::getLevelName(Logger::CRITICAL));
         $this->assertEquals('unknown', Logger::getLevelName(0));
     }
 
@@ -242,7 +241,7 @@ class LoggerTest extends TestCase
      */
     public function testParseMessage($message, array $context, $expected)
     {
-        $this->logger->log(LogLevel::INFO, $message, $context);
+        $this->logger->log(Logger::INFO, $message, $context);
         [, $message] = $this->logger->messages[0];
         $this->assertEquals($expected, $message);
     }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -34,17 +34,17 @@ class LoggerTest extends TestCase
     public function testLog()
     {
         $memory = memory_get_usage();
-        $this->logger->log(Logger::INFO, 'test1');
+        $this->logger->log(Logger::INFO_LEVEL, 'test1');
         $this->assertCount(1, $this->logger->messages);
-        $this->assertEquals(Logger::INFO, $this->logger->messages[0][0]);
+        $this->assertEquals(Logger::INFO_LEVEL, $this->logger->messages[0][0]);
         $this->assertEquals('test1', $this->logger->messages[0][1]);
         $this->assertEquals('application', $this->logger->messages[0][2]['category']);
         $this->assertEquals([], $this->logger->messages[0][2]['trace']);
         $this->assertGreaterThanOrEqual($memory, $this->logger->messages[0][2]['memory']);
 
-        $this->logger->log(Logger::ERROR, 'test2', ['category' => 'category']);
+        $this->logger->log(Logger::ERROR_LEVEL, 'test2', ['category' => 'category']);
         $this->assertCount(2, $this->logger->messages);
-        $this->assertEquals(Logger::ERROR, $this->logger->messages[1][0]);
+        $this->assertEquals(Logger::ERROR_LEVEL, $this->logger->messages[1][0]);
         $this->assertEquals('test2', $this->logger->messages[1][1]);
         $this->assertEquals('category', $this->logger->messages[1][2]['category']);
         $this->assertEquals([], $this->logger->messages[1][2]['trace']);
@@ -58,9 +58,9 @@ class LoggerTest extends TestCase
     {
         $memory = memory_get_usage();
         $this->logger->setTraceLevel(3);
-        $this->logger->log(Logger::INFO, 'test3');
+        $this->logger->log(Logger::INFO_LEVEL, 'test3');
         $this->assertCount(1, $this->logger->messages);
-        $this->assertEquals(Logger::INFO, $this->logger->messages[0][0]);
+        $this->assertEquals(Logger::INFO_LEVEL, $this->logger->messages[0][0]);
         $this->assertEquals('test3', $this->logger->messages[0][1]);
         $this->assertEquals('application', $this->logger->messages[0][2]['category']);
         $this->assertEquals([
@@ -101,7 +101,7 @@ class LoggerTest extends TestCase
             ->getMock();
         $logger->setFlushInterval(1);
         $logger->expects($this->exactly(1))->method('flush');
-        $logger->log(Logger::INFO, 'test1');
+        $logger->log(Logger::INFO_LEVEL, 'test1');
     }
 
     /**
@@ -152,13 +152,13 @@ class LoggerTest extends TestCase
      */
     public function testGetLevelName()
     {
-        $this->assertEquals('info', Logger::getLevelName(Logger::INFO));
-        $this->assertEquals('error', Logger::getLevelName(Logger::ERROR));
-        $this->assertEquals('warning', Logger::getLevelName(Logger::WARNING));
-        $this->assertEquals('debug', Logger::getLevelName(Logger::DEBUG));
-        $this->assertEquals('emergency', Logger::getLevelName(Logger::EMERGENCY));
-        $this->assertEquals('alert', Logger::getLevelName(Logger::ALERT));
-        $this->assertEquals('critical', Logger::getLevelName(Logger::CRITICAL));
+        $this->assertEquals('info', Logger::getLevelName(Logger::INFO_LEVEL));
+        $this->assertEquals('error', Logger::getLevelName(Logger::ERROR_LEVEL));
+        $this->assertEquals('warning', Logger::getLevelName(Logger::WARNING_LEVEL));
+        $this->assertEquals('debug', Logger::getLevelName(Logger::DEBUG_LEVEL));
+        $this->assertEquals('emergency', Logger::getLevelName(Logger::EMERGENCY_LEVEL));
+        $this->assertEquals('alert', Logger::getLevelName(Logger::ALERT_LEVEL));
+        $this->assertEquals('critical', Logger::getLevelName(Logger::CRITICAL_LEVEL));
         $this->assertEquals('unknown', Logger::getLevelName(0));
     }
 
@@ -241,7 +241,7 @@ class LoggerTest extends TestCase
      */
     public function testParseMessage($message, array $context, $expected)
     {
-        $this->logger->log(Logger::INFO, $message, $context);
+        $this->logger->log(Logger::INFO_LEVEL, $message, $context);
         [, $message] = $this->logger->messages[0];
         $this->assertEquals($expected, $message);
     }

--- a/tests/TargetTest.php
+++ b/tests/TargetTest.php
@@ -24,13 +24,13 @@ class TargetTest extends TestCase
             [[], ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']],
             [['levels' => []], ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']],
             [
-                ['levels' => [Logger::INFO, Logger::WARNING, Logger::ERROR, Logger::DEBUG]],
+                ['levels' => [Logger::INFO_LEVEL, Logger::WARNING_LEVEL, Logger::ERROR_LEVEL, Logger::DEBUG_LEVEL]],
                 ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'],
             ],
             [['levels' => ['error']], ['B', 'G', 'H', 'I']],
-            [['levels' => [Logger::ERROR]], ['B', 'G', 'H', 'I']],
+            [['levels' => [Logger::ERROR_LEVEL]], ['B', 'G', 'H', 'I']],
             [['levels' => ['error', 'warning']], ['B', 'C', 'G', 'H', 'I']],
-            [['levels' => [Logger::ERROR, Logger::WARNING]], ['B', 'C', 'G', 'H', 'I']],
+            [['levels' => [Logger::ERROR_LEVEL, Logger::WARNING_LEVEL]], ['B', 'C', 'G', 'H', 'I']],
 
             [['categories' => ['application']], ['A', 'B', 'C', 'D', 'E']],
             [['categories' => ['application*']], ['A', 'B', 'C', 'D', 'E', 'F']],
@@ -43,9 +43,9 @@ class TargetTest extends TestCase
             [['except' => ['Yiisoft\Db\*']], ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']],
             [['categories' => ['Yiisoft*'], 'except' => ['Yiisoft\Db\*']], ['G', 'H']],
 
-            [['categories' => ['application', 'Yiisoft.Db.*'], 'levels' => [Logger::ERROR]], ['B', 'G', 'H']],
-            [['categories' => ['application'], 'levels' => [Logger::ERROR]], ['B']],
-            [['categories' => ['application'], 'levels' => [Logger::ERROR, Logger::WARNING]], ['B', 'C']],
+            [['categories' => ['application', 'Yiisoft.Db.*'], 'levels' => [Logger::ERROR_LEVEL]], ['B', 'G', 'H']],
+            [['categories' => ['application'], 'levels' => [Logger::ERROR_LEVEL]], ['B']],
+            [['categories' => ['application'], 'levels' => [Logger::ERROR_LEVEL, Logger::WARNING_LEVEL]], ['B', 'C']],
         ];
     }
 
@@ -66,15 +66,15 @@ class TargetTest extends TestCase
         $logger = new Logger(['test' => $target]);
 
         $logger->setFlushInterval(1);
-        $logger->log(Logger::INFO, 'testA');
-        $logger->log(Logger::ERROR, 'testB');
-        $logger->log(Logger::WARNING, 'testC');
-        $logger->log(Logger::DEBUG, 'testD');
-        $logger->log(Logger::INFO, 'testE', ['category' => 'application']);
-        $logger->log(Logger::INFO, 'testF', ['category' => 'application.components.Test']);
-        $logger->log(Logger::ERROR, 'testG', ['category' => 'Yiisoft.Db.Command']);
-        $logger->log(Logger::ERROR, 'testH', ['category' => 'Yiisoft.Db.Command.whatever']);
-        $logger->log(Logger::ERROR, 'testI', ['category' => 'Yiisoft\Db\Command::query']);
+        $logger->log(Logger::INFO_LEVEL, 'testA');
+        $logger->log(Logger::ERROR_LEVEL, 'testB');
+        $logger->log(Logger::WARNING_LEVEL, 'testC');
+        $logger->log(Logger::DEBUG_LEVEL, 'testD');
+        $logger->log(Logger::INFO_LEVEL, 'testE', ['category' => 'application']);
+        $logger->log(Logger::INFO_LEVEL, 'testF', ['category' => 'application.components.Test']);
+        $logger->log(Logger::ERROR_LEVEL, 'testG', ['category' => 'Yiisoft.Db.Command']);
+        $logger->log(Logger::ERROR_LEVEL, 'testH', ['category' => 'Yiisoft.Db.Command.whatever']);
+        $logger->log(Logger::ERROR_LEVEL, 'testI', ['category' => 'Yiisoft\Db\Command::query']);
 
         $this->assertCount(count($expected), static::$messages, 'Expected ' . implode(',', $expected) . ', got ' . implode(',', array_column(static::$messages, 0)));
         $i = 0;
@@ -152,7 +152,7 @@ class TargetTest extends TestCase
         $target = $this->getMockForAbstractClass(Target::class);
 
         $text = 'message';
-        $level = Logger::INFO;
+        $level = Logger::INFO_LEVEL;
         $category = 'application';
         $timestamp = 1508160390.6083;
 

--- a/tests/TargetTest.php
+++ b/tests/TargetTest.php
@@ -7,7 +7,6 @@
 
 namespace Yiisoft\Log\Tests;
 
-use Psr\Log\LogLevel;
 use Yiisoft\Log\Logger;
 use Yiisoft\Log\Target;
 use PHPUnit\Framework\TestCase;
@@ -25,13 +24,13 @@ class TargetTest extends TestCase
             [[], ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']],
             [['levels' => []], ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I']],
             [
-                ['levels' => [LogLevel::INFO, LogLevel::WARNING, LogLevel::ERROR, LogLevel::DEBUG]],
+                ['levels' => [Logger::INFO, Logger::WARNING, Logger::ERROR, Logger::DEBUG]],
                 ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I'],
             ],
             [['levels' => ['error']], ['B', 'G', 'H', 'I']],
-            [['levels' => [LogLevel::ERROR]], ['B', 'G', 'H', 'I']],
+            [['levels' => [Logger::ERROR]], ['B', 'G', 'H', 'I']],
             [['levels' => ['error', 'warning']], ['B', 'C', 'G', 'H', 'I']],
-            [['levels' => [LogLevel::ERROR, LogLevel::WARNING]], ['B', 'C', 'G', 'H', 'I']],
+            [['levels' => [Logger::ERROR, Logger::WARNING]], ['B', 'C', 'G', 'H', 'I']],
 
             [['categories' => ['application']], ['A', 'B', 'C', 'D', 'E']],
             [['categories' => ['application*']], ['A', 'B', 'C', 'D', 'E', 'F']],
@@ -44,9 +43,9 @@ class TargetTest extends TestCase
             [['except' => ['Yiisoft\Db\*']], ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']],
             [['categories' => ['Yiisoft*'], 'except' => ['Yiisoft\Db\*']], ['G', 'H']],
 
-            [['categories' => ['application', 'Yiisoft.Db.*'], 'levels' => [LogLevel::ERROR]], ['B', 'G', 'H']],
-            [['categories' => ['application'], 'levels' => [LogLevel::ERROR]], ['B']],
-            [['categories' => ['application'], 'levels' => [LogLevel::ERROR, LogLevel::WARNING]], ['B', 'C']],
+            [['categories' => ['application', 'Yiisoft.Db.*'], 'levels' => [Logger::ERROR]], ['B', 'G', 'H']],
+            [['categories' => ['application'], 'levels' => [Logger::ERROR]], ['B']],
+            [['categories' => ['application'], 'levels' => [Logger::ERROR, Logger::WARNING]], ['B', 'C']],
         ];
     }
 
@@ -67,15 +66,15 @@ class TargetTest extends TestCase
         $logger = new Logger(['test' => $target]);
 
         $logger->setFlushInterval(1);
-        $logger->log(LogLevel::INFO, 'testA');
-        $logger->log(LogLevel::ERROR, 'testB');
-        $logger->log(LogLevel::WARNING, 'testC');
-        $logger->log(LogLevel::DEBUG, 'testD');
-        $logger->log(LogLevel::INFO, 'testE', ['category' => 'application']);
-        $logger->log(LogLevel::INFO, 'testF', ['category' => 'application.components.Test']);
-        $logger->log(LogLevel::ERROR, 'testG', ['category' => 'Yiisoft.Db.Command']);
-        $logger->log(LogLevel::ERROR, 'testH', ['category' => 'Yiisoft.Db.Command.whatever']);
-        $logger->log(LogLevel::ERROR, 'testI', ['category' => 'Yiisoft\Db\Command::query']);
+        $logger->log(Logger::INFO, 'testA');
+        $logger->log(Logger::ERROR, 'testB');
+        $logger->log(Logger::WARNING, 'testC');
+        $logger->log(Logger::DEBUG, 'testD');
+        $logger->log(Logger::INFO, 'testE', ['category' => 'application']);
+        $logger->log(Logger::INFO, 'testF', ['category' => 'application.components.Test']);
+        $logger->log(Logger::ERROR, 'testG', ['category' => 'Yiisoft.Db.Command']);
+        $logger->log(Logger::ERROR, 'testH', ['category' => 'Yiisoft.Db.Command.whatever']);
+        $logger->log(Logger::ERROR, 'testI', ['category' => 'Yiisoft\Db\Command::query']);
 
         $this->assertCount(count($expected), static::$messages, 'Expected ' . implode(',', $expected) . ', got ' . implode(',', array_column(static::$messages, 0)));
         $i = 0;
@@ -153,7 +152,7 @@ class TargetTest extends TestCase
         $target = $this->getMockForAbstractClass(Target::class);
 
         $text = 'message';
-        $level = LogLevel::INFO;
+        $level = Logger::INFO;
         $category = 'application';
         $timestamp = 1508160390.6083;
 


### PR DESCRIPTION
In order to avoid explicitly requiring `psr/log` in projects, for filtering or using `$logger->log()`