### PR TITLE
Change visibility Target::filterMessages() method

### DIFF
--- a/src/Target.php
+++ b/src/Target.php
@@ -194,7 +194,7 @@ abstract class Target
      * @param array $except the message categories to exclude. If empty, it means all categories are allowed.
      * @return array the filtered messages.
      */
-    public static function filterMessages(
+    protected static function filterMessages(
         array $messages,
         array $levels = [],
         array $categories = [],


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -

Changes the `Target::filterMessages()` method visibility to `protected`. This method is only used inside the class and its childs.
