### PR TITLE
Removed `Formatter::defaultFormat()` dependency from global locale

### DIFF
--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -140,8 +140,14 @@ final class Formatter
      */
     private function getTime(Message $message): string
     {
+        $currentLocale = \setlocale(LC_NUMERIC, '0');
+        \setlocale(LC_NUMERIC, 'C');
+
         $timestamp = (string) $message->context('time', microtime(true));
         $format = strpos($timestamp, '.') === false ? 'U' : 'U.u';
+
+        \setlocale(LC_NUMERIC, $currentLocale);
+
         return DateTime::createFromFormat($format, $timestamp)->format($this->timestampFormat);
     }
 

--- a/tests/Message/FormatterTest.php
+++ b/tests/Message/FormatterTest.php
@@ -67,6 +67,22 @@ final class FormatterTest extends TestCase
     /**
      * @dataProvider contextProvider
      *
+     * @param array $context
+     * @param string $expected
+     */
+    public function testDefaultFormatWithOtherLocal(array $context, string $expected): void
+    {
+        $currentLocale = \setlocale(LC_NUMERIC, '0');
+        $this->assertNotFalse(\setlocale(LC_NUMERIC, 'ru_RU'));
+
+        $this->testDefaultFormat($context, $expected);
+
+        \setlocale(LC_NUMERIC, $currentLocale);
+    }
+
+    /**
+     * @dataProvider contextProvider
+     *
      * @param array $commonContext
      * @param string $expected
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ✔️
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #76 
