### PR TITLE
Fix test with time and add `ext-json` to `require-dev` section of composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,10 +25,11 @@
         "yiisoft/var-dumper": "^1.0"
     },
     "require-dev": {
+        "ext-json": "*",
         "phpunit/phpunit": "^9.5",
-        "roave/infection-static-analysis-plugin": "^1.16",
+        "roave/infection-static-analysis-plugin": "^1.18",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.18"
+        "vimeo/psalm": "^4.22"
     },
     "provide": {
         "psr/log-implementation": "1.0.0"

--- a/tests/Message/FormatterTest.php
+++ b/tests/Message/FormatterTest.php
@@ -136,14 +136,21 @@ final class FormatterTest extends TestCase
     public function testFormatWithSetFormatAndSetPrefix(): void
     {
         $this->formatter->setFormat(static fn (Message $message) => "({$message->level()}) {$message->message()}");
-        $this->formatter->setPrefix(static function (Message $message) {
-            $category = strtoupper($message->context('category'));
-            $time = date('H:i:s', $message->context('time'));
-            return "{$category}: ({$time})";
-        });
-        $message = new Message(LogLevel::INFO, 'message', ['category' => 'app', 'time' => 1508160390]);
-        $expected = 'APP: (13:26:30)(info) message';
-        $this->assertSame($expected, $this->formatter->format($message, []));
+        $this->formatter->setPrefix(
+            static function (Message $message) {
+                $category = strtoupper($message->context('category'));
+                $time = date('H:i:s', $message->context('time'));
+                return "{$category}: ({$time})";
+            }
+        );
+
+        $time = 1508160390;
+        $message = new Message(LogLevel::INFO, 'message', ['category' => 'app', 'time' => $time]);
+
+        $this->assertSame(
+            'APP: (' . date('H:i:s', $time) . ')(info) message',
+            $this->formatter->format($message, [])
+        );
     }
 
     public function testFormatWithContextAndSetFormat(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -
