### PR TITLE
Separate chain calls

### DIFF
--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -286,8 +286,12 @@ final class LoggerTest extends TestCase
 
         $this->logger->log(LogLevel::INFO, 'test');
         $this->assertSame(1, $this->target->getExportCount());
-        $this->assertSame('info', $this->target->getExportMessages()[0]->level());
-        $this->assertSame('test', $this->target->getExportMessages()[0]->message());
+        $this->assertSame('info', $this->target
+            ->getExportMessages()[0]
+            ->level());
+        $this->assertSame('test', $this->target
+            ->getExportMessages()[0]
+            ->message());
     }
 
     public function testFlushWithDispatch(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Readability fix  | according to https://github.com/yiisoft/docs/issues/155, chain calls must be put on separate lines.
----
Found some more.