### PR TITLE
Refactoring: replace `Logger::validateLevel()` to `Logger::assert*`

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -10,6 +10,8 @@ on:
       - 'phpunit.xml.dist'
 
   push:
+    branches:
+      - master
     paths-ignore:
       - 'docs/**'
       - 'README.md'
@@ -28,4 +30,4 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.0', '8.1']
+        ['8.0', '8.1', '8.2', '8.3']

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -30,4 +30,12 @@ jobs:
       os: >-
         ['ubuntu-latest']
       php: >-
-        ['8.0', '8.1', '8.2', '8.3']
+        ['8.0', '8.1', '8.2']
+  psalm83:
+    uses: yiisoft/actions/.github/workflows/psalm.yml@master
+    with:
+      psalm-config: 'psalm-8.3.xml'
+      os: >-
+        ['ubuntu-latest']
+      php: >-
+        ['8.3']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## 2.0.1 under development
 
 - Bug #84: Change the type of the `$level` parameter in the `Message` constructor to `string` (@dood-)
+- New #104: Add new static methods `Logger::assertLevelIsValid()`, `Logger::assertLevelIsString()` and
+  `Logger::assertLevelIsSupported()` (@vjik)
+- Chg #104: Deprecate method `Logger::validateLevel()` (@vjik)
 
 ## 2.0.0 May 22, 2022
 

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "maglnet/composer-require-checker": "^4.4",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "^1.0.0",
+        "rector/rector": "^1.0.*",
         "roave/infection-static-analysis-plugin": "^1.18",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.30|^5.24"

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "require-dev": {
         "maglnet/composer-require-checker": "^4.4",
         "phpunit/phpunit": "^9.5",
-        "rector/rector": "^1.0.*",
+        "rector/rector": "1.0.*",
         "roave/infection-static-analysis-plugin": "^1.18",
         "spatie/phpunit-watcher": "^1.23",
         "vimeo/psalm": "^4.30|^5.24"

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "rector/rector": "^1.0.0",
         "roave/infection-static-analysis-plugin": "^1.18",
         "spatie/phpunit-watcher": "^1.23",
-        "vimeo/psalm": "^4.22"
+        "vimeo/psalm": "^4.30|^5.24"
     },
     "provide": {
         "psr/log-implementation": "1.0.0"

--- a/psalm-8.3.xml
+++ b/psalm-8.3.xml
@@ -15,6 +15,7 @@
     </projectFiles>
     <issueHandlers>
         <MixedAssignment errorLevel="suppress" />
+        <MissingClassConstType errorLevel="suppress" />
     </issueHandlers>
 </psalm>
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -13,5 +13,8 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <MixedAssignment errorLevel="suppress" />
+    </issueHandlers>
 </psalm>
 

--- a/psalm.xml
+++ b/psalm.xml
@@ -15,6 +15,7 @@
     </projectFiles>
     <issueHandlers>
         <MixedAssignment errorLevel="suppress" />
+        <MissingClassConstType errorLevel="suppress" />
     </issueHandlers>
 </psalm>
 

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -111,6 +111,8 @@ final class Logger implements LoggerInterface
     /**
      * Returns the text display of the specified level.
      *
+     * @param mixed $level The message level, e.g. {@see LogLevel::ERROR}, {@see LogLevel::WARNING}.
+     *
      * @throws \Psr\Log\InvalidArgumentException for invalid log message level.
      *
      * @return string The text display of the level.

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -111,7 +111,6 @@ final class Logger implements LoggerInterface
     /**
      * Returns the text display of the specified level.
      *
-     *
      * @throws \Psr\Log\InvalidArgumentException for invalid log message level.
      *
      * @return string The text display of the level.

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -148,7 +148,7 @@ final class Logger implements LoggerInterface
 
     /**
      * @psalm-param LogMessageContext $context
-     * @psalm-suppress MoreSpecificImplementedParamType
+     * @psalm-suppress MoreSpecificImplementedParamType,MixedArgumentTypeCoercion
      */
     public function log(mixed $level, string|Stringable $message, array $context = []): void
     {
@@ -232,6 +232,13 @@ final class Logger implements LoggerInterface
         return $this;
     }
 
+    /**
+     * Asserts that the log message level is valid.
+     *
+     * @param mixed $level The message level.
+     *
+     * @throws \Psr\Log\InvalidArgumentException When the log message level is not a string or is not supported.
+     */
     public static function assertLevelIsValid(mixed $level): void
     {
         self::assertLevelIsString($level);
@@ -239,6 +246,12 @@ final class Logger implements LoggerInterface
     }
 
     /**
+     * Asserts that the log message level is a string.
+     *
+     * @param mixed $level The message level.
+     *
+     * @throws \Psr\Log\InvalidArgumentException When the log message level is not a string.
+     *
      * @psalm-assert string $level
      */
     public static function assertLevelIsString(mixed $level): void
@@ -252,6 +265,13 @@ final class Logger implements LoggerInterface
         );
     }
 
+    /**
+     * Asserts that the log message level is supported.
+     *
+     * @param string $level The message level.
+     *
+     * @throws \Psr\Log\InvalidArgumentException When the log message level is not supported.
+     */
     public static function assertLevelIsSupported(string $level): void
     {
         if (in_array($level, self::LEVELS, true)) {

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -111,12 +111,10 @@ final class Logger implements LoggerInterface
     /**
      * Returns the text display of the specified level.
      *
-     * @param mixed $level The message level, e.g. {@see LogLevel::ERROR}, {@see LogLevel::WARNING}.
      *
      * @throws \Psr\Log\InvalidArgumentException for invalid log message level.
      *
      * @return string The text display of the level.
-     *
      * @deprecated since 2.1, to be removed in 3.0. Use {@see LogLevel::assertLevelIsValid()} instead.
      */
     public static function validateLevel(mixed $level): string

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -116,6 +116,8 @@ final class Logger implements LoggerInterface
      * @throws \Psr\Log\InvalidArgumentException for invalid log message level.
      *
      * @return string The text display of the level.
+     *
+     * @deprecated since 2.1, to be removed in 3.0. Use {@see LogLevel::assertLevelIsValid()} instead.
      */
     public static function validateLevel(mixed $level): string
     {
@@ -146,12 +148,13 @@ final class Logger implements LoggerInterface
     }
 
     /**
-     * @param string $level
      * @psalm-param LogMessageContext $context
      * @psalm-suppress MoreSpecificImplementedParamType
      */
     public function log(mixed $level, string|Stringable $message, array $context = []): void
     {
+        self::assertLevelIsString($level);
+
         $context['time'] ??= microtime(true);
         $context['trace'] ??= $this->collectTrace(debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS));
         $context['memory'] ??= memory_get_usage();
@@ -228,6 +231,41 @@ final class Logger implements LoggerInterface
 
         $this->excludedTracePaths = $excludedTracePaths;
         return $this;
+    }
+
+    public static function assertLevelIsValid(mixed $level): void
+    {
+        self::assertLevelIsString($level);
+        self::assertLevelIsSupported($level);
+    }
+
+    /**
+     * @psalm-assert string $level
+     */
+    public static function assertLevelIsString(mixed $level): void
+    {
+        if (is_string($level)) {
+            return;
+        }
+
+        throw new \Psr\Log\InvalidArgumentException(
+            sprintf('The log message level must be a string, %s provided.', gettype($level))
+        );
+    }
+
+    public static function assertLevelIsSupported(string $level): void
+    {
+        if (in_array($level, self::LEVELS, true)) {
+            return;
+        }
+
+        throw new \Psr\Log\InvalidArgumentException(
+            sprintf(
+                'Invalid log message level "%s" provided. The following values are supported: "%s".',
+                $level,
+                implode('", "', self::LEVELS)
+            )
+        );
     }
 
     /**

--- a/src/Message.php
+++ b/src/Message.php
@@ -68,7 +68,8 @@ final class Message
      */
     public function __construct(string $level, string|Stringable $message, array $context = [])
     {
-        $this->level = Logger::validateLevel($level);
+        Logger::assertLevelIsSupported($level);
+        $this->level = $level;
         $this->message = $this->parse($message, $context);
         $this->context = $context;
     }

--- a/src/Message.php
+++ b/src/Message.php
@@ -100,7 +100,6 @@ final class Message
      * If no name is specified, the entire context is returned.
      *
      * @param string|null $name The context parameter name.
-     * @param mixed $default If the context parameter does not exist, the `$default` will be returned.
      *
      * @return mixed The context parameter value.
      * @psalm-return LogMessageContext|mixed

--- a/src/Message.php
+++ b/src/Message.php
@@ -100,6 +100,7 @@ final class Message
      * If no name is specified, the entire context is returned.
      *
      * @param string|null $name The context parameter name.
+     * @param mixed $default If the context parameter does not exist, the `$default` will be returned.
      *
      * @return mixed The context parameter value.
      * @psalm-return LogMessageContext|mixed

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -250,7 +250,6 @@ final class Formatter
     /**
      * Converts a value to a string.
      *
-     *
      * @return string Converted string.
      */
     private function convertToString(mixed $value): string

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -250,6 +250,8 @@ final class Formatter
     /**
      * Converts a value to a string.
      *
+     * @param mixed $value The value to convert.
+     *
      * @return string Converted string.
      */
     private function convertToString(mixed $value): string

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -250,7 +250,6 @@ final class Formatter
     /**
      * Converts a value to a string.
      *
-     * @param mixed $value The value to convert
      *
      * @return string Converted string.
      */

--- a/src/Target.php
+++ b/src/Target.php
@@ -160,7 +160,8 @@ abstract class Target
     public function setLevels(array $levels): self
     {
         foreach ($levels as $key => $level) {
-            $levels[$key] = Logger::validateLevel($level);
+            Logger::assertLevelIsValid($level);
+            $levels[$key] = $level;
         }
 
         $this->levels = $levels;

--- a/tests/TargetTest.php
+++ b/tests/TargetTest.php
@@ -132,8 +132,6 @@ final class TargetTest extends TestCase
 
     /**
      * @dataProvider invalidCallableEnabledProvider
-     *
-     * @param mixed $value
      */
     public function testIsEnabledThrowExceptionForCallableReturnNotBoolean(callable $value): void
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | -