### PR TITLE
Replace `gettype()` to `get_debug_type()` in exception messages generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 - New #113: Add `Message::trace()` method (@vjik)
 - New #114: Add `Message::time()` method (@vjik)
 - Chg #116: Deprecate methods `setCommonContext()` and `getCommonContext()` in `Target` class (@vjik)
+- Chg #118: Replace `gettype()` to `get_debug_type()` in exception messages generation (@vjik)
 
 ## 2.0.0 May 22, 2022
 

--- a/src/ContextProvider/SystemContextProvider.php
+++ b/src/ContextProvider/SystemContextProvider.php
@@ -79,7 +79,7 @@ final class SystemContextProvider implements ContextProviderInterface
                 throw new InvalidArgumentException(
                     sprintf(
                         'The trace path must be a string, %s received.',
-                        gettype($excludedTracePath)
+                        get_debug_type($excludedTracePath)
                     )
                 );
             }

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -15,7 +15,6 @@ use Yiisoft\Log\ContextProvider\SystemContextProvider;
 use Yiisoft\Log\ContextProvider\ContextProviderInterface;
 
 use function count;
-use function gettype;
 use function implode;
 use function in_array;
 use function is_string;
@@ -113,7 +112,7 @@ final class Logger implements LoggerInterface
         if (!is_string($level)) {
             throw new \Psr\Log\InvalidArgumentException(sprintf(
                 'The log message level must be a string, %s provided.',
-                gettype($level)
+                get_debug_type($level)
             ));
         }
 
@@ -250,7 +249,7 @@ final class Logger implements LoggerInterface
         }
 
         throw new \Psr\Log\InvalidArgumentException(
-            sprintf('The log message level must be a string, %s provided.', gettype($level))
+            sprintf('The log message level must be a string, %s provided.', get_debug_type($level))
         );
     }
 

--- a/src/Message/CategoryFilter.php
+++ b/src/Message/CategoryFilter.php
@@ -8,7 +8,6 @@ use InvalidArgumentException;
 
 use Yiisoft\Log\Message;
 
-use function gettype;
 use function is_string;
 use function rtrim;
 use function sprintf;
@@ -123,7 +122,7 @@ final class CategoryFilter
             if (!is_string($category)) {
                 throw new InvalidArgumentException(sprintf(
                     'The log message category must be a string, %s received.',
-                    gettype($category)
+                    get_debug_type($category)
                 ));
             }
         }

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -8,7 +8,6 @@ use RuntimeException;
 use Yiisoft\Log\Message;
 use Yiisoft\VarDumper\VarDumper;
 
-use function gettype;
 use function implode;
 use function is_string;
 use function is_object;
@@ -103,7 +102,7 @@ final class Formatter
         if (!is_string($formatted)) {
             throw new RuntimeException(sprintf(
                 'The PHP callable "format" must return a string, %s received.',
-                gettype($formatted)
+                get_debug_type($formatted)
             ));
         }
 
@@ -151,7 +150,7 @@ final class Formatter
         if (!is_string($prefix)) {
             throw new RuntimeException(sprintf(
                 'The PHP callable "prefix" must return a string, %s received.',
-                gettype($prefix)
+                get_debug_type($prefix)
             ));
         }
 

--- a/src/StreamTarget.php
+++ b/src/StreamTarget.php
@@ -12,7 +12,6 @@ use function fclose;
 use function flock;
 use function fopen;
 use function fwrite;
-use function gettype;
 use function get_resource_type;
 use function is_resource;
 use function sprintf;
@@ -79,7 +78,7 @@ final class StreamTarget extends Target
         if (!is_resource($stream) || get_resource_type($stream) !== 'stream') {
             throw new InvalidArgumentException(sprintf(
                 'Invalid stream provided. It must be a string stream identifier or a stream resource, "%s" received.',
-                gettype($stream),
+                get_debug_type($stream),
             ));
         }
 

--- a/src/Target.php
+++ b/src/Target.php
@@ -11,7 +11,6 @@ use Yiisoft\Log\Message\CategoryFilter;
 use Yiisoft\Log\Message\Formatter;
 
 use function count;
-use function gettype;
 use function in_array;
 use function is_bool;
 use function sprintf;
@@ -307,7 +306,7 @@ abstract class Target
         if (!is_bool($enabled = ($this->enabled)())) {
             throw new RuntimeException(sprintf(
                 'The PHP callable "enabled" must returns a boolean, %s received.',
-                gettype($enabled)
+                get_debug_type($enabled)
             ));
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ❌
| Breaks BC?    | ❌
| Fixed issues  | #110 