### PR TITLE
Fix #146: Move `Target` configuration to constructor parameters and deprecate the corresponding setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.2 under development
 
-- no changes in this release.
+- Enh #XXX: Move `Target` configuration to constructor parameters and deprecate the corresponding setters (@WarLikeLaux)
 
 ## 2.2.1 March 22, 2026
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2.2.2 under development
 
-- Enh #XXX: Move `Target` configuration to constructor parameters and deprecate the corresponding setters (@WarLikeLaux)
+- Enh #146: Move `Target` configuration to constructor parameters and deprecate the corresponding setters (@WarLikeLaux)
 
 ## 2.2.1 March 22, 2026
 

--- a/README.md
+++ b/README.md
@@ -130,11 +130,15 @@ $logger->setFlushInterval(100); // default is 1000
 
 Each log target also collects and stores messages in memory.
 Message exporting in a target follows the same principle as in the logger.
-To change the number of stored messages, call the `\Yiisoft\Log\Target::setExportInterval()` method:
+To change the number of stored messages, pass the `exportInterval` constructor parameter:
 
 ```php
-$target->setExportInterval(100); // default is 1000
+$target = new \Yiisoft\Log\StreamTarget(exportInterval: 100); // default is 1000
 ```
+
+> The `setExportInterval()` setter is deprecated since 2.2.2; use the constructor parameter instead. The same
+> applies to `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`, `setTimestampFormat()`
+> and `setEnabled()`.
 
 > Note: All message flushing and exporting also occurs when the application ends.
 

--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ To change the number of stored messages, pass the `exportInterval` constructor p
 $target = new \Yiisoft\Log\StreamTarget(exportInterval: 100); // default is 1000
 ```
 
-The `setExportInterval()` setter is deprecated since 2.2.2; use the constructor parameter instead. The same
+The `setExportInterval()` setter is deprecated; use the constructor parameter instead. The same
 applies to `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`, `setTimestampFormat()`
 and `setEnabled()`.
 

--- a/README.md
+++ b/README.md
@@ -136,9 +136,9 @@ To change the number of stored messages, pass the `exportInterval` constructor p
 $target = new \Yiisoft\Log\StreamTarget(exportInterval: 100); // default is 1000
 ```
 
-> The `setExportInterval()` setter is deprecated since 2.2.2; use the constructor parameter instead. The same
-> applies to `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`, `setTimestampFormat()`
-> and `setEnabled()`.
+The `setExportInterval()` setter is deprecated since 2.2.2; use the constructor parameter instead. The same
+applies to `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`, `setTimestampFormat()`
+and `setEnabled()`.
 
 > Note: All message flushing and exporting also occurs when the application ends.
 

--- a/docs/guide/ru/README.md
+++ b/docs/guide/ru/README.md
@@ -120,7 +120,7 @@ $logger->setFlushInterval(100); // по умолчанию 1000
 $target = new \Yiisoft\Log\StreamTarget(exportInterval: 100); // по умолчанию 1000
 ```
 
-Сеттер `setExportInterval()` объявлен устаревшим с версии 2.2.2, используйте вместо него параметр конструктора.
+Сеттер `setExportInterval()` объявлен устаревшим, используйте вместо него параметр конструктора.
 То же касается `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`,
 `setTimestampFormat()` и `setEnabled()`.
 

--- a/docs/guide/ru/README.md
+++ b/docs/guide/ru/README.md
@@ -114,11 +114,15 @@ $logger->setFlushInterval(100); // по умолчанию 1000
 ```
 
 Каждый таргет тоже накапливает сообщения в памяти. Экспорт работает по тому же принципу.
-Количество сообщений перед экспортом настраивается через `\Yiisoft\Log\Target::setExportInterval()`:
+Количество сообщений перед экспортом задаётся параметром конструктора `exportInterval`:
 
 ```php
-$target->setExportInterval(100); // по умолчанию 1000
+$target = new \Yiisoft\Log\StreamTarget(exportInterval: 100); // по умолчанию 1000
 ```
+
+> Сеттер `setExportInterval()` объявлен устаревшим с версии 2.2.2, используйте вместо него параметр конструктора.
+> То же касается `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`,
+> `setTimestampFormat()` и `setEnabled()`.
 
 > Примечание: сброс и экспорт всех сообщений также происходит при завершении приложения.
 

--- a/docs/guide/ru/README.md
+++ b/docs/guide/ru/README.md
@@ -120,9 +120,9 @@ $logger->setFlushInterval(100); // по умолчанию 1000
 $target = new \Yiisoft\Log\StreamTarget(exportInterval: 100); // по умолчанию 1000
 ```
 
-> Сеттер `setExportInterval()` объявлен устаревшим с версии 2.2.2, используйте вместо него параметр конструктора.
-> То же касается `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`,
-> `setTimestampFormat()` и `setEnabled()`.
+Сеттер `setExportInterval()` объявлен устаревшим с версии 2.2.2, используйте вместо него параметр конструктора.
+То же касается `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`,
+`setTimestampFormat()` и `setEnabled()`.
 
 > Примечание: сброс и экспорт всех сообщений также происходит при завершении приложения.
 

--- a/src/Message/CategoryFilter.php
+++ b/src/Message/CategoryFilter.php
@@ -46,6 +46,18 @@ final class CategoryFilter
     private array $exclude = [];
 
     /**
+     * @param string[] $include The list of included log message categories.
+     * @param string[] $exclude The list of excluded log message categories.
+     *
+     * @throws InvalidArgumentException for invalid log message categories structure.
+     */
+    public function __construct(array $include = [], array $exclude = [])
+    {
+        $this->include($include);
+        $this->exclude($exclude);
+    }
+
+    /**
      * Sets the log message categories to be included.
      *
      * @param string[] $categories List of log message categories to be included.

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -22,6 +22,9 @@ use function is_int;
  */
 final class Formatter
 {
+    /**
+     * @var string
+     */
     private const DEFAULT_TIMESTAMP_FORMAT = 'Y-m-d H:i:s.u';
 
     /**

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -47,6 +47,25 @@ final class Formatter
     private string $timestampFormat = 'Y-m-d H:i:s.u';
 
     /**
+     * @param callable|null $format A PHP callable that returns a string representation of the log message.
+     * Its signature should be `function (Message $message, array $commonContext): string;`.
+     * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
+     * Its signature should be `function (Message $message, array $commonContext): string;`.
+     * @param string|null $timestampFormat The date format for the log timestamp. Defaults to `Y-m-d H:i:s.u`.
+     */
+    public function __construct(
+        ?callable $format = null,
+        ?callable $prefix = null,
+        ?string $timestampFormat = null,
+    ) {
+        $this->format = $format;
+        $this->prefix = $prefix;
+        if ($timestampFormat !== null) {
+            $this->timestampFormat = $timestampFormat;
+        }
+    }
+
+    /**
      * Sets the format for the string representation of the log message.
      *
      * @param callable $format The PHP callable to get a string representation of the log message.

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -22,48 +22,22 @@ use function is_int;
  */
 final class Formatter
 {
-    /**
-     * @var callable|null PHP callable that returns a string representation of the log message.
-     *
-     * If not set, {@see Formatter::defaultFormat()} will be used.
-     *
-     * The signature of the callable should be `function (Message $message, array $commonContext): string;`.
-     */
-    private $format;
-
-    /**
-     * @var callable|null PHP callable that returns a string to be prefixed to every exported message.
-     *
-     * If not set, {@see Formatter::getPrefix()} will be used, which prefixes
-     * the message with context information such as user IP, user ID and session ID.
-     *
-     * The signature of the callable should be `function (Message $message, array $commonContext): string;`.
-     */
-    private $prefix;
-
-    /**
-     * @var string The date format for the log timestamp. Defaults to `Y-m-d H:i:s.u`.
-     */
-    private string $timestampFormat = 'Y-m-d H:i:s.u';
+    private const DEFAULT_TIMESTAMP_FORMAT = 'Y-m-d H:i:s.u';
 
     /**
      * @param callable|null $format A PHP callable that returns a string representation of the log message.
+     * If not set, {@see Formatter::defaultFormat()} is used.
      * Its signature should be `function (Message $message, array $commonContext): string;`.
      * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
+     * If not set, {@see Formatter::getPrefix()} is used.
      * Its signature should be `function (Message $message, array $commonContext): string;`.
      * @param string|null $timestampFormat The date format for the log timestamp. Defaults to `Y-m-d H:i:s.u`.
      */
     public function __construct(
-        ?callable $format = null,
-        ?callable $prefix = null,
-        ?string $timestampFormat = null,
-    ) {
-        $this->format = $format;
-        $this->prefix = $prefix;
-        if ($timestampFormat !== null) {
-            $this->timestampFormat = $timestampFormat;
-        }
-    }
+        private $format = null,
+        private $prefix = null,
+        private ?string $timestampFormat = null,
+    ) {}
 
     /**
      * Sets the format for the string representation of the log message.
@@ -139,7 +113,7 @@ final class Formatter
      */
     private function defaultFormat(Message $message, array $commonContext): string
     {
-        $time = $message->time()->format($this->timestampFormat);
+        $time = $message->time()->format($this->timestampFormat ?? self::DEFAULT_TIMESTAMP_FORMAT);
         $prefix = $this->getPrefix($message, $commonContext);
         $context = $this->getContext($message, $commonContext);
 

--- a/src/Message/Formatter.php
+++ b/src/Message/Formatter.php
@@ -22,9 +22,6 @@ use function is_int;
  */
 final class Formatter
 {
-    /**
-     * @var string
-     */
     private const DEFAULT_TIMESTAMP_FORMAT = 'Y-m-d H:i:s.u';
 
     /**

--- a/src/PsrTarget.php
+++ b/src/PsrTarget.php
@@ -18,25 +18,25 @@ final class PsrTarget extends Target
      * @param LoggerInterface $logger The logger instance to be used for messages processing.
      * @param string[] $levels The {@see LogLevel log message levels} that this target is interested in.
      * @param string[] $categories The log message categories that this target is interested in.
-     * @param string[] $except The log message categories that this target is NOT interested in.
+     * @param string[] $exceptCategories The log message categories that this target is NOT interested in.
      * @param callable|null $format A PHP callable that returns a string representation of the log message.
      * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
      * @param string|null $timestampFormat The date format for the log timestamp.
-     * @param int|null $exportInterval How many messages should be accumulated before they are exported.
+     * @param int $exportInterval How many messages should be accumulated before they are exported.
      * @param bool|callable $enabled Whether this target is enabled, or a PHP callable that returns a boolean.
      */
     public function __construct(
         private LoggerInterface $logger,
         array $levels = [],
         array $categories = [],
-        array $except = [],
+        array $exceptCategories = [],
         ?callable $format = null,
         ?callable $prefix = null,
         ?string $timestampFormat = null,
-        ?int $exportInterval = null,
+        int $exportInterval = self::DEFAULT_EXPORT_INTERVAL,
         bool|callable $enabled = true,
     ) {
-        parent::__construct($levels, $categories, $except, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
+        parent::__construct($levels, $categories, $exceptCategories, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
     }
 
     /**

--- a/src/PsrTarget.php
+++ b/src/PsrTarget.php
@@ -17,10 +17,26 @@ final class PsrTarget extends Target
      *
      * @param LoggerInterface $logger The logger instance to be used for messages processing.
      * @param string[] $levels The {@see LogLevel log message levels} that this target is interested in.
+     * @param string[] $categories The log message categories that this target is interested in.
+     * @param string[] $except The log message categories that this target is NOT interested in.
+     * @param callable|null $format A PHP callable that returns a string representation of the log message.
+     * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
+     * @param string|null $timestampFormat The date format for the log timestamp.
+     * @param int|null $exportInterval How many messages should be accumulated before they are exported.
+     * @param bool|callable $enabled Whether this target is enabled, or a PHP callable that returns a boolean.
      */
-    public function __construct(private LoggerInterface $logger, array $levels = [])
-    {
-        parent::__construct($levels);
+    public function __construct(
+        private LoggerInterface $logger,
+        array $levels = [],
+        array $categories = [],
+        array $except = [],
+        ?callable $format = null,
+        ?callable $prefix = null,
+        ?string $timestampFormat = null,
+        ?int $exportInterval = null,
+        bool|callable $enabled = true,
+    ) {
+        parent::__construct($levels, $categories, $except, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
     }
 
     /**

--- a/src/StreamTarget.php
+++ b/src/StreamTarget.php
@@ -32,25 +32,25 @@ final class StreamTarget extends Target
      * @param resource|string $stream A string stream identifier or a stream resource.
      * @param string[] $levels The {@see LogLevel log message levels} that this target is interested in.
      * @param string[] $categories The log message categories that this target is interested in.
-     * @param string[] $except The log message categories that this target is NOT interested in.
+     * @param string[] $exceptCategories The log message categories that this target is NOT interested in.
      * @param callable|null $format A PHP callable that returns a string representation of the log message.
      * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
      * @param string|null $timestampFormat The date format for the log timestamp.
-     * @param int|null $exportInterval How many messages should be accumulated before they are exported.
+     * @param int $exportInterval How many messages should be accumulated before they are exported.
      * @param bool|callable $enabled Whether this target is enabled, or a PHP callable that returns a boolean.
      */
     public function __construct(
         private $stream = 'php://stdout',
         array $levels = [],
         array $categories = [],
-        array $except = [],
+        array $exceptCategories = [],
         ?callable $format = null,
         ?callable $prefix = null,
         ?string $timestampFormat = null,
-        ?int $exportInterval = null,
+        int $exportInterval = self::DEFAULT_EXPORT_INTERVAL,
         bool|callable $enabled = true,
     ) {
-        parent::__construct($levels, $categories, $except, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
+        parent::__construct($levels, $categories, $exceptCategories, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
     }
 
     protected function export(): void

--- a/src/StreamTarget.php
+++ b/src/StreamTarget.php
@@ -31,10 +31,26 @@ final class StreamTarget extends Target
     /**
      * @param resource|string $stream A string stream identifier or a stream resource.
      * @param string[] $levels The {@see LogLevel log message levels} that this target is interested in.
+     * @param string[] $categories The log message categories that this target is interested in.
+     * @param string[] $except The log message categories that this target is NOT interested in.
+     * @param callable|null $format A PHP callable that returns a string representation of the log message.
+     * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
+     * @param string|null $timestampFormat The date format for the log timestamp.
+     * @param int|null $exportInterval How many messages should be accumulated before they are exported.
+     * @param bool|callable $enabled Whether this target is enabled, or a PHP callable that returns a boolean.
      */
-    public function __construct(private $stream = 'php://stdout', array $levels = [])
-    {
-        parent::__construct($levels);
+    public function __construct(
+        private $stream = 'php://stdout',
+        array $levels = [],
+        array $categories = [],
+        array $except = [],
+        ?callable $format = null,
+        ?callable $prefix = null,
+        ?string $timestampFormat = null,
+        ?int $exportInterval = null,
+        bool|callable $enabled = true,
+    ) {
+        parent::__construct($levels, $categories, $except, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
     }
 
     protected function export(): void

--- a/src/Target.php
+++ b/src/Target.php
@@ -9,6 +9,7 @@ use RuntimeException;
 use Yiisoft\Log\ContextProvider\CommonContextProvider;
 use Yiisoft\Log\Message\CategoryFilter;
 use Yiisoft\Log\Message\Formatter;
+use Psr\Log\LogLevel;
 
 use function count;
 use function in_array;
@@ -28,6 +29,8 @@ use function sprintf;
  */
 abstract class Target
 {
+    public const DEFAULT_EXPORT_INTERVAL = 1000;
+
     private CategoryFilter $categories;
     private Formatter $formatter;
 
@@ -37,36 +40,9 @@ abstract class Target
     private array $messages = [];
 
     /**
-     * @var string[] The log message levels that this target is interested in.
-     *
-     * @see LogLevel See constants for valid level names.
-     *
-     * The value should be an array of level names.
-     *
-     * For example:
-     *
-     * ```php
-     * ['error', 'warning'],
-     * // or
-     * [LogLevel::ERROR, LogLevel::WARNING]
-     * ```
-     *
-     * Defaults is empty array, meaning all available levels.
-     */
-    private array $levels = [];
-
-    /**
      * @var array The user parameters in the `key => value` format that should be logged in a each message.
      */
     private array $commonContext = [];
-
-    /**
-     * @var int How many log messages should be accumulated before they are exported.
-     *
-     * Defaults to 1000. Note that messages will always be exported when the application terminates.
-     * Set this property to be 0 if you don't want to export messages until the application terminates.
-     */
-    private int $exportInterval = 1000;
 
     /**
      * @var bool|callable Enables or disables the current target to export.
@@ -76,36 +52,28 @@ abstract class Target
     /**
      * When defining a constructor in child classes, you must call `parent::__construct()`.
      *
-     * @param string[] $levels The {@see \Psr\Log\LogLevel log message levels} that this target is interested in.
+     * @param string[] $levels The {@see LogLevel log message levels} that this target is interested in.
      * @param string[] $categories The log message categories that this target is interested in.
-     * @param string[] $except The log message categories that this target is NOT interested in.
+     * @param string[] $exceptCategories The log message categories that this target is NOT interested in.
      * @param callable|null $format A PHP callable that returns a string representation of the log message.
      * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
      * @param string|null $timestampFormat The date format for the log timestamp.
-     * @param int|null $exportInterval How many messages should be accumulated before they are exported.
+     * @param int $exportInterval How many messages should be accumulated before they are exported.
      * @param bool|callable $enabled Whether this target is enabled, or a PHP callable that returns a boolean.
      */
     public function __construct(
-        array $levels = [],
+        private array $levels = [],
         array $categories = [],
-        array $except = [],
+        array $exceptCategories = [],
         ?callable $format = null,
         ?callable $prefix = null,
         ?string $timestampFormat = null,
-        ?int $exportInterval = null,
+        private int $exportInterval = self::DEFAULT_EXPORT_INTERVAL,
         bool|callable $enabled = true,
     ) {
-        $this->categories = new CategoryFilter();
-        $this->categories->include($categories);
-        $this->categories->exclude($except);
+        $this->assertLevelsAreValid($this->levels);
+        $this->categories = new CategoryFilter($categories, $exceptCategories);
         $this->formatter = new Formatter($format, $prefix, $timestampFormat);
-        $this->assertLevelsAreValid($levels);
-        $this->levels = $levels;
-
-        if ($exportInterval !== null) {
-            $this->exportInterval = $exportInterval;
-        }
-
         $this->enabled = $enabled;
     }
 
@@ -144,7 +112,7 @@ abstract class Target
      *
      * @see CategoryFilter::$include
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$categories` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$categories` constructor parameter instead.
      */
     public function setCategories(array $categories): self
     {
@@ -163,7 +131,7 @@ abstract class Target
      *
      * @see CategoryFilter::$exclude
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$except` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$exceptCategories` constructor parameter instead.
      */
     public function setExcept(array $except): self
     {
@@ -172,7 +140,7 @@ abstract class Target
     }
 
     /**
-     * Sets a list of {@see \Psr\Log\LogLevel log message levels} that current target is interested in.
+     * Sets a list of {@see LogLevel log message levels} that current target is interested in.
      *
      * @param string[] $levels The list of log message levels.
      *
@@ -182,7 +150,7 @@ abstract class Target
      *
      * @see Target::$levels
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$levels` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$levels` constructor parameter instead.
      */
     public function setLevels(array $levels): self
     {
@@ -217,7 +185,7 @@ abstract class Target
      *
      * @see Formatter::$format
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$format` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$format` constructor parameter instead.
      */
     public function setFormat(callable $format): self
     {
@@ -234,7 +202,7 @@ abstract class Target
      *
      * @see Formatter::$prefix
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$prefix` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$prefix` constructor parameter instead.
      */
     public function setPrefix(callable $prefix): self
     {
@@ -251,7 +219,7 @@ abstract class Target
      *
      * @see Target::$exportInterval
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$exportInterval` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$exportInterval` constructor parameter instead.
      */
     public function setExportInterval(int $exportInterval): self
     {
@@ -268,7 +236,7 @@ abstract class Target
      *
      * @see Target::$timestampFormat
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$timestampFormat` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$timestampFormat` constructor parameter instead.
      */
     public function setTimestampFormat(string $format): self
     {
@@ -287,7 +255,7 @@ abstract class Target
      *
      * @see Target::$enabled
      *
-     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$enabled` constructor parameter instead.
+     * @deprecated To be removed in 3.0. Use the `$enabled` constructor parameter instead.
      */
     public function setEnabled(callable $value): self
     {

--- a/src/Target.php
+++ b/src/Target.php
@@ -77,12 +77,36 @@ abstract class Target
      * When defining a constructor in child classes, you must call `parent::__construct()`.
      *
      * @param string[] $levels The {@see \Psr\Log\LogLevel log message levels} that this target is interested in.
+     * @param string[] $categories The log message categories that this target is interested in.
+     * @param string[] $except The log message categories that this target is NOT interested in.
+     * @param callable|null $format A PHP callable that returns a string representation of the log message.
+     * @param callable|null $prefix A PHP callable that returns a string to be prefixed to every exported message.
+     * @param string|null $timestampFormat The date format for the log timestamp.
+     * @param int|null $exportInterval How many messages should be accumulated before they are exported.
+     * @param bool|callable $enabled Whether this target is enabled, or a PHP callable that returns a boolean.
      */
-    public function __construct(array $levels = [])
-    {
+    public function __construct(
+        array $levels = [],
+        array $categories = [],
+        array $except = [],
+        ?callable $format = null,
+        ?callable $prefix = null,
+        ?string $timestampFormat = null,
+        ?int $exportInterval = null,
+        bool|callable $enabled = true,
+    ) {
         $this->categories = new CategoryFilter();
-        $this->formatter = new Formatter();
-        $this->setLevels($levels);
+        $this->categories->include($categories);
+        $this->categories->exclude($except);
+        $this->formatter = new Formatter($format, $prefix, $timestampFormat);
+        $this->assertLevelsAreValid($levels);
+        $this->levels = $levels;
+
+        if ($exportInterval !== null) {
+            $this->exportInterval = $exportInterval;
+        }
+
+        $this->enabled = $enabled;
     }
 
     /**
@@ -119,6 +143,8 @@ abstract class Target
      * @return self
      *
      * @see CategoryFilter::$include
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$categories` constructor parameter instead.
      */
     public function setCategories(array $categories): self
     {
@@ -136,6 +162,8 @@ abstract class Target
      * @return self
      *
      * @see CategoryFilter::$exclude
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$except` constructor parameter instead.
      */
     public function setExcept(array $except): self
     {
@@ -153,14 +181,12 @@ abstract class Target
      * @return self
      *
      * @see Target::$levels
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$levels` constructor parameter instead.
      */
     public function setLevels(array $levels): self
     {
-        foreach ($levels as $key => $level) {
-            Logger::assertLevelIsValid($level);
-            $levels[$key] = $level;
-        }
-
+        $this->assertLevelsAreValid($levels);
         $this->levels = $levels;
         return $this;
     }
@@ -190,6 +216,8 @@ abstract class Target
      * @return self
      *
      * @see Formatter::$format
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$format` constructor parameter instead.
      */
     public function setFormat(callable $format): self
     {
@@ -205,6 +233,8 @@ abstract class Target
      * @return self
      *
      * @see Formatter::$prefix
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$prefix` constructor parameter instead.
      */
     public function setPrefix(callable $prefix): self
     {
@@ -220,6 +250,8 @@ abstract class Target
      * @return self
      *
      * @see Target::$exportInterval
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$exportInterval` constructor parameter instead.
      */
     public function setExportInterval(int $exportInterval): self
     {
@@ -235,6 +267,8 @@ abstract class Target
      * @return self
      *
      * @see Target::$timestampFormat
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$timestampFormat` constructor parameter instead.
      */
     public function setTimestampFormat(string $format): self
     {
@@ -252,6 +286,8 @@ abstract class Target
      * @return self
      *
      * @see Target::$enabled
+     *
+     * @deprecated since 2.2.2, to be removed in 3.0. Use the `$enabled` constructor parameter instead.
      */
     public function setEnabled(callable $value): self
     {
@@ -370,6 +406,20 @@ abstract class Target
     protected function getCommonContext(): array
     {
         return $this->commonContext;
+    }
+
+    /**
+     * Asserts that every given log message level is valid.
+     *
+     * @param string[] $levels The list of log message levels.
+     *
+     * @throws InvalidArgumentException for invalid log message level.
+     */
+    private function assertLevelsAreValid(array $levels): void
+    {
+        foreach ($levels as $level) {
+            Logger::assertLevelIsValid($level);
+        }
     }
 
     /**

--- a/src/Target.php
+++ b/src/Target.php
@@ -30,7 +30,7 @@ use function sprintf;
 abstract class Target
 {
     /**
-     * @var int
+     * @psalm-suppress MissingClassConstType
      */
     public const DEFAULT_EXPORT_INTERVAL = 1000;
 

--- a/src/Target.php
+++ b/src/Target.php
@@ -43,6 +43,25 @@ abstract class Target
     private array $messages = [];
 
     /**
+     * @var string[] The log message levels that this target is interested in.
+     *
+     * @see LogLevel See constants for valid level names.
+     *
+     * The value should be an array of level names.
+     *
+     * For example:
+     *
+     * ```php
+     * ['error', 'warning'],
+     * // or
+     * [LogLevel::ERROR, LogLevel::WARNING]
+     * ```
+     *
+     * Defaults is empty array, meaning all available levels.
+     */
+    private array $levels = [];
+
+    /**
      * @var array The user parameters in the `key => value` format that should be logged in a each message.
      */
     private array $commonContext = [];
@@ -65,7 +84,7 @@ abstract class Target
      * @param bool|callable $enabled Whether this target is enabled, or a PHP callable that returns a boolean.
      */
     public function __construct(
-        private array $levels = [],
+        array $levels = [],
         array $categories = [],
         array $exceptCategories = [],
         ?callable $format = null,
@@ -74,9 +93,10 @@ abstract class Target
         private int $exportInterval = self::DEFAULT_EXPORT_INTERVAL,
         bool|callable $enabled = true,
     ) {
-        $this->assertLevelsAreValid($this->levels);
         $this->categories = new CategoryFilter($categories, $exceptCategories);
         $this->formatter = new Formatter($format, $prefix, $timestampFormat);
+        /** @psalm-suppress DeprecatedMethod */
+        $this->setLevels($levels);
         $this->enabled = $enabled;
     }
 
@@ -157,7 +177,10 @@ abstract class Target
      */
     public function setLevels(array $levels): self
     {
-        $this->assertLevelsAreValid($levels);
+        foreach ($levels as $level) {
+            Logger::assertLevelIsValid($level);
+        }
+
         $this->levels = $levels;
         return $this;
     }
@@ -377,20 +400,6 @@ abstract class Target
     protected function getCommonContext(): array
     {
         return $this->commonContext;
-    }
-
-    /**
-     * Asserts that every given log message level is valid.
-     *
-     * @param string[] $levels The list of log message levels.
-     *
-     * @throws InvalidArgumentException for invalid log message level.
-     */
-    private function assertLevelsAreValid(array $levels): void
-    {
-        foreach ($levels as $level) {
-            Logger::assertLevelIsValid($level);
-        }
     }
 
     /**

--- a/src/Target.php
+++ b/src/Target.php
@@ -29,6 +29,9 @@ use function sprintf;
  */
 abstract class Target
 {
+    /**
+     * @var int
+     */
     public const DEFAULT_EXPORT_INTERVAL = 1000;
 
     private CategoryFilter $categories;

--- a/tests/TargetTest.php
+++ b/tests/TargetTest.php
@@ -346,6 +346,81 @@ final class TargetTest extends TestCase
         $this->assertSame((int) $export, $this->target->getExportCount());
     }
 
+    public function testTimestampFormatViaConstructor(): void
+    {
+        $target = new DummyTarget(timestampFormat: 'Y-m-d H:i:s');
+        $target->collect([new Message(LogLevel::INFO, 'message', ['category' => 'app', 'time' => 1_508_160_390])], true);
+        $expected = '2017-10-16 13:26:30 [info][app] message'
+            . "\n\nMessage context:\n\ncategory: 'app'\ntime: 1508160390\n";
+
+        $this->assertSame($expected, $target->formatMessages());
+    }
+
+    public function testExportIntervalViaConstructor(): void
+    {
+        $target = new DummyTarget(exportInterval: 1);
+        $target->collect([new Message(LogLevel::INFO, 'message', ['category' => 'app'])], false);
+
+        $this->assertSame(1, $target->getExportCount());
+    }
+
+    public function testFormatViaConstructor(): void
+    {
+        $target = new DummyTarget(format: static fn(Message $message) => "[{$message->level()}] {$message->message()}");
+        $target->collect([new Message(LogLevel::INFO, 'message', ['category' => 'app'])], true);
+
+        $this->assertSame('[info] message', $target->formatMessages());
+    }
+
+    public function testPrefixViaConstructor(): void
+    {
+        $target = new DummyTarget(prefix: static fn(): string => 'PFX: ', timestampFormat: 'Y-m-d H:i:s');
+        $target->collect([new Message(LogLevel::INFO, 'message', ['category' => 'app', 'time' => 1_508_160_390])], true);
+        $expected = '2017-10-16 13:26:30 PFX: [info][app] message'
+            . "\n\nMessage context:\n\ncategory: 'app'\ntime: 1508160390\n";
+
+        $this->assertSame($expected, $target->formatMessages());
+    }
+
+    public function testCategoriesViaConstructor(): void
+    {
+        $target = new DummyTarget(categories: ['app']);
+        $target->collect(
+            [
+                new Message(LogLevel::INFO, 'in', ['category' => 'app']),
+                new Message(LogLevel::INFO, 'out', ['category' => 'other']),
+            ],
+            true,
+        );
+        $messages = $target->getExportMessages();
+
+        $this->assertCount(1, $messages);
+        $this->assertSame('in', $messages[0]->message());
+    }
+
+    public function testExceptViaConstructor(): void
+    {
+        $target = new DummyTarget(except: ['app']);
+        $target->collect(
+            [
+                new Message(LogLevel::INFO, 'in', ['category' => 'other']),
+                new Message(LogLevel::INFO, 'out', ['category' => 'app']),
+            ],
+            true,
+        );
+        $messages = $target->getExportMessages();
+
+        $this->assertCount(1, $messages);
+        $this->assertSame('in', $messages[0]->message());
+    }
+
+    public function testEnabledViaConstructor(): void
+    {
+        $target = new DummyTarget(enabled: false);
+
+        $this->assertFalse($target->isEnabled());
+    }
+
     public function contextProvider(): array
     {
         return [

--- a/tests/TargetTest.php
+++ b/tests/TargetTest.php
@@ -400,7 +400,7 @@ final class TargetTest extends TestCase
 
     public function testExceptViaConstructor(): void
     {
-        $target = new DummyTarget(except: ['app']);
+        $target = new DummyTarget(exceptCategories: ['app']);
         $target->collect(
             [
                 new Message(LogLevel::INFO, 'in', ['category' => 'other']),

--- a/tests/TestAsset/DummyTarget.php
+++ b/tests/TestAsset/DummyTarget.php
@@ -14,10 +14,18 @@ final class DummyTarget extends Target
     private array $exportMessages = [];
     private Formatter $exportFormatter;
 
-    public function __construct(array $levels = [])
-    {
-        parent::__construct($levels);
-        $this->exportFormatter = new Formatter();
+    public function __construct(
+        array $levels = [],
+        array $categories = [],
+        array $except = [],
+        ?callable $format = null,
+        ?callable $prefix = null,
+        ?string $timestampFormat = null,
+        ?int $exportInterval = null,
+        bool|callable $enabled = true,
+    ) {
+        parent::__construct($levels, $categories, $except, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
+        $this->exportFormatter = new Formatter($format, $prefix, $timestampFormat);
     }
 
     public function export(): void

--- a/tests/TestAsset/DummyTarget.php
+++ b/tests/TestAsset/DummyTarget.php
@@ -17,14 +17,14 @@ final class DummyTarget extends Target
     public function __construct(
         array $levels = [],
         array $categories = [],
-        array $except = [],
+        array $exceptCategories = [],
         ?callable $format = null,
         ?callable $prefix = null,
         ?string $timestampFormat = null,
-        ?int $exportInterval = null,
+        int $exportInterval = self::DEFAULT_EXPORT_INTERVAL,
         bool|callable $enabled = true,
     ) {
-        parent::__construct($levels, $categories, $except, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
+        parent::__construct($levels, $categories, $exceptCategories, $format, $prefix, $timestampFormat, $exportInterval, $enabled);
         $this->exportFormatter = new Formatter($format, $prefix, $timestampFormat);
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Is bugfix?    | ❌
| New feature?  | ✔️
| Docs added?   | ✔️
| Tests added?  | ✔️
| Breaks BC?    | ❌

## What does this PR do?

Follow-up to #140. Move `Target`'s configuration setters to constructor parameters and mark the setters as deprecated.

New constructor parameters on `Target`, forwarded by `StreamTarget` and `PsrTarget`:

- `$levels` (already present)
- `$categories`, `$exceptCategories` - category filters
- `$format`, `$prefix`, `$timestampFormat` - formatting
- `$exportInterval` - export batching
- `$enabled` - enable/disable state

Deprecated (to be removed in 3.0), each replaced by the matching constructor parameter: `setCategories()`, `setExcept()`, `setLevels()`, `setFormat()`, `setPrefix()`, `setExportInterval()`, `setTimestampFormat()`, `setEnabled()`.

### Use cases

```php
$target = new StreamTarget(
    levels: [LogLevel::ERROR],
    exceptCategories: ['Yiisoft\Db\*'],
    timestampFormat: 'Y-m-d H:i:s',
    exportInterval: 100,
);
```

No BC break: the setters keep working (deprecated only), and every constructor parameter is optional with the current default.

The internal `Formatter` gets the matching constructor parameters too. Its setters stay (not deprecated) because the deprecated `Target` setters delegate to them, and that delegation has to keep working until they are all removed in 3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Logging targets now support complete configuration via constructor parameters. Setter methods (setCategories, setExcept, setLevels, setFormat, setPrefix, setExportInterval, setTimestampFormat, setEnabled) are deprecated since 2.2.2.

* **Documentation**
  * Updated README and guides to demonstrate constructor-based configuration approach with examples.

* **Tests**
  * Added comprehensive test coverage for constructor-based logging target configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->